### PR TITLE
Fix for nginx having a wrong checksum.

### DIFF
--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -1,6 +1,7 @@
 node.default['nginx']['init_style'] = "init"
 node.default['nginx']['install_method'] = 'source'
 node.default['nginx']['source']['version'] = '1.4.1'
+node.default['nginx']['source']['checksum'] = 'bca5d1e89751ba29406185e1736c390412603a7e6b604f5b4575281f6565d119'
 node.default['nginx']['source']['url'] = "http://nginx.org/download/nginx-#{node['nginx']['source']['version']}.tar.gz"
 node.default['nginx']['source']['prefix']                  = "/opt/nginx-#{node['nginx']['source']['version']}"
 node.default['nginx']['source']['conf_path']               = "#{node['nginx']['dir']}/nginx.conf"


### PR DESCRIPTION
Seems that the nginx cookbook updated their nginx default version to 1.4.4 and updated the checksum to match. The rogue cookbook is setting nginx version to 1.4.1 but not setting the checksum which then defaults to 1.4.4 checksum, which fails the test.
