### PR TITLE
Update the geonode_authorize_layer logic to support new GeoNode perms.

### DIFF
--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -70,8 +70,11 @@ DECLARE
 view_perm integer;
 change_perm integer;
 manage_perm integer;
+download_perm integer;
+edit_perm integer;
 roles varchar[] = '{anonymous,NULL}';
 ct integer;
+layer_ct integer;
 user RECORD;
 layer RECORD;
 group_ids integer[];
@@ -85,6 +88,12 @@ if (not FOUND) then
 	-- no layer
 	return 'nl';
 end if;
+
+if (user_name IS NULL or user_name = '') then
+        user_name = 'AnonymousUser';
+end if;
+
+
 if (user_name IS NOT NULL) then
 	SELECT INTO user * FROM "people_profile" WHERE "people_profile"."username" = user_name;
 	if (not FOUND) then
@@ -123,18 +132,37 @@ SELECT INTO manage_perm "auth_permission"."id"
 	WHERE ("auth_permission"."codename" = E'change_resourcebase_permissions'
 	AND "django_content_type"."app_label" = E'base' );
 
+  SELECT INTO download_perm "auth_permission"."id"
+	FROM "auth_permission" INNER JOIN "django_content_type"
+	ON ("auth_permission"."content_type_id" = "django_content_type"."id")
+	WHERE ("auth_permission"."codename" = E'download_resourcebase'
+	AND "django_content_type"."app_label" = E'base' );
+
+SELECT INTO edit_perm "auth_permission"."id"
+	FROM "auth_permission" INNER JOIN "django_content_type"
+	ON ("auth_permission"."content_type_id" = "django_content_type"."id")
+	WHERE ("auth_permission"."codename" = E'change_layer_data'
+	AND "django_content_type"."app_label" = E'layers' );
+
 SELECT INTO ct "django_content_type"."id"
 	FROM "django_content_type"
 	WHERE ("django_content_type"."model" = E'resourcebase'
 	AND "django_content_type"."app_label" = E'base' );
 
-SELECT INTO group_ids array_agg("groups_groupmember"."group_id")
+SELECT INTO layer_ct "django_content_type"."id"
+	FROM "django_content_type"
+	WHERE ("django_content_type"."model" = E'layer'
+	AND "django_content_type"."app_label" = E'layers' );
+
+SELECT INTO group_ids array_agg("groups_groupmember"."group_id" + 1)
   FROM "groups_groupmember"
   WHERE "groups_groupmember"."user_id" = "user".id;
 
-
 --RAISE NOTICE 'View Perm: %', view_perm;
 --RAISE NOTICE 'Change Perm: %', change_perm;
+--RAISE NOTICE 'Edit Data Perm: %', edit_perm;
+--RAISE NOTICE 'Manage Layer Perm: %', manage_perm;
+--RAISE NOTICE 'Can Download Perm: %', download_perm;
 --RAISE NOTICE 'Content Type: %', ct;
 --RAISE NOTICE 'User ID: %', "user".id;
 --RAISE NOTICE 'Layer ID: %', "layer".id;
@@ -150,8 +178,14 @@ if (user_name IS NOT NULL) then
 		AND "guardian_userobjectpermission"."content_type_id" = ct
 		AND ("guardian_userobjectpermission"."user_id" = "user".id or "guardian_userobjectpermission"."user_id" = -1)
 		AND "guardian_userobjectpermission"."object_pk"::integer = "layer".id
+		) OR
+		(("auth_permission"."id" = change_perm or "auth_permission"."id" = edit_perm)
+		AND "guardian_userobjectpermission"."content_type_id" = layer_ct
+		AND ("guardian_userobjectpermission"."user_id" = "user".id or "guardian_userobjectpermission"."user_id" = -1)
+		AND "guardian_userobjectpermission"."object_pk"::integer = "layer".id
 		);
 	if (FOUND) then return 'ur-rw'; end if;
+
 
   -- user role, user has read-write permissions via group membership
   PERFORM "guardian_groupobjectpermission"."object_pk"
@@ -159,17 +193,22 @@ if (user_name IS NOT NULL) then
 		INNER JOIN "auth_permission"
 		ON ("guardian_groupobjectpermission"."permission_id" = "auth_permission"."id")
 		WHERE (("auth_permission"."id" = change_perm or "auth_permission"."id" = manage_perm)
-		AND "guardian_groupobjectpermission"."content_type_id" = ct
+		AND ("guardian_groupobjectpermission"."content_type_id" = ct)
 		AND "guardian_groupobjectpermission"."group_id" = ANY (group_ids)
 		AND "guardian_groupobjectpermission"."object_pk"::integer = "layer".id
-		);
+		OR
+		(("auth_permission"."id" = edit_perm)
+		AND ("guardian_groupobjectpermission"."content_type_id" = layer_ct)
+		AND "guardian_groupobjectpermission"."group_id" = ANY (group_ids)
+		AND "guardian_groupobjectpermission"."object_pk"::integer = "layer".id));
 	if (FOUND) then return 'group-rw'; end if;
+
 
 	PERFORM "guardian_userobjectpermission"."object_pk"
 		FROM "guardian_userobjectpermission"
 		INNER JOIN "auth_permission"
 		ON ("guardian_userobjectpermission"."permission_id" = "auth_permission"."id")
-		WHERE ("auth_permission"."id" = view_perm
+		WHERE (("auth_permission"."id" = view_perm or "auth_permission"."id" = download_perm)
 		AND "guardian_userobjectpermission"."content_type_id" = ct
 		AND ("guardian_userobjectpermission"."user_id" = "user".id or "guardian_userobjectpermission"."user_id" = -1)
 		AND "guardian_userobjectpermission"."object_pk"::integer = "layer".id
@@ -181,13 +220,12 @@ if (user_name IS NOT NULL) then
 		FROM "guardian_groupobjectpermission"
 		INNER JOIN "auth_permission"
 		ON ("guardian_groupobjectpermission"."permission_id" = "auth_permission"."id")
-		WHERE ("auth_permission"."id" = view_perm
+		WHERE (("auth_permission"."id" = view_perm or "auth_permission"."id" = download_perm)
 		AND "guardian_groupobjectpermission"."content_type_id" = ct
 		AND "guardian_groupobjectpermission"."group_id" = ANY (group_ids)
 		AND "guardian_groupobjectpermission"."object_pk"::integer = "layer".id
 		);
 	if (FOUND) then return 'group-ro'; end if;
-
 
 
 end if;


### PR DESCRIPTION
Note this does not implement the 'Can edit styles permission' or the 'Can edit metadata' permission since they don't have a Geoserver equivalent implemented in the geoserver-geonode-ext database client: https://github.com/GeoNode/geoserver-geonode-ext/blob/master/src/main/java/org/geonode/security/DatabaseSecurityClient.java.