### PR TITLE
CORS support for GeoNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Attributes
 - `node['rogue']['rogue_geonode']['settings']['PROXY_ALLOWED_HOSTS']` = An array of hosts that the GeoNode can forward requests to.
 - `node['rogue']['rogue_geonode']['settings']['SLACK_ENABLED']` = Enable slack contrib app
 - `node['rogue']['rogue_geonode']['settings']['SLACK_WEBHOOK_URL']` = Slack webhook url.
+- `node['rogue']['rogue_geonode']['settings']['CORS_ENABLED']` = Enable CORS (Cross-origin resource sharing)
 - `node['rogue']['ssh']['public_key']` = A public key used for the rogue user to support file synchronization.
 - `node['rogue']['ssh']['public_key_remote_file']` = The location where to store the public key on the guest machine.
 - `node['unison']['user']` = A hash with the username and password for the `unison` user.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -116,6 +116,7 @@ default['rogue']['rogue_geonode']['settings']['CLASSIFICATION_TEXT'] = nil
 default['rogue']['rogue_geonode']['settings']['CLASSIFICATION_LINK'] = nil
 default['rogue']['rogue_geonode']['settings']['SLACK_ENABLED'] = false
 default['rogue']['rogue_geonode']['settings']['SLACK_WEBHOOK_URL'] = nil
+default['rogue']['rogue_geonode']['settings']['CORS_ENABLED'] = false
 
 default['rogue']['stig']['url'] = 'https://github.com/ROGUE-JCTD/stig.git'
 default['rogue']['stig']['branch'] = 'release-1.0'

--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -124,3 +124,6 @@ NOTIFICATION_LOCK_LOCATION = '/var/lib/geonode/rogue'
 
 SLACK_ENABLED = <%= @settings['SLACK_ENABLED'] ? "True": "False" %>
 SLACK_WEBHOOK_URLS = ['<%= @settings['SLACK_WEBHOOK_URL'] %>']
+
+# Enable CORS (https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
+CORS_ENABLED = <%= @settings['CORS_ENABLED'] ? "True": "False" %>


### PR DESCRIPTION
Linked to #47 and PR https://github.com/ROGUE-JCTD/rogue_geonode/pull/97.  Adds cors support for GeoNode.  Still need to set up CORS for geoserver separately.